### PR TITLE
Use email contact value from settings form.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -108,7 +108,7 @@
         $('#pageserviceheader').html(response.service_header.replace(/(?:\r\n|\r|\n)/g, '<br />'));
         $('#pagechartheader').html(response.chart_header.replace(/(?:\r\n|\r|\n)/g, '<br />'));
         $('#pageemailformheader').html(response.email_form_header.replace(/(?:\r\n|\r|\n)/g, '<br />'));
-        //$('#pageemailaddress').html(response.data.email_address);
+        contact_email = response.email_address;
         //$('#pageemailname').html(response.data.email_name);
         //$('#pageemailbody').html(response.email_body.replace(/(?:\r\n|\r|\n)/g, '<br />'));
         $('#pagemainheader').html(response.main_header.replace(/(?:\r\n|\r|\n)/g, '<br />'));
@@ -569,7 +569,7 @@ function validateEmail(Email) {
             emailaddresses.push(email);
         }
         if ($("#emailtordmsg").prop("checked")) {
-            emailaddresses.push("rich.marisa@gmail.com"); // rdmsg-services@cornell.edu
+            emailaddresses.push(contact_email);
         }
         if (emailaddresses.length > 0) {
             var csrf_token;


### PR DESCRIPTION
Removes the hardcoded 'helpdesk' contact email address and uses the one from the module settings form. Fixes #8.